### PR TITLE
Add default NBNS delay

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,6 +20,7 @@ Optional arguments:
   -R 5               The number of Garbage SMB Auth requests to send to the attacker
   -c true               Continue Emailing After a Detection, could lead to spam
   -d 5                  Time delay (in seconds) between NBNS broadcasts, reduces network noise
+  			Default is set to 1 second between NBNS broadcasts.
 
 Example Usage:
 	sudo python spoofspotter.py -i 192.168.1.161 -b 192.168.1.255 -n NBNSHOSTQUERY -s 192.168.1.2 -e karl.fosaaen@example.com -f test.log

--- a/SpoofSpotter.py
+++ b/SpoofSpotter.py
@@ -102,6 +102,8 @@ def sender():
 		# If there's a delay set, then wait
 		if args.d:
 			time.sleep(float(args.d))
+		else:
+			time.sleep(float(1))
 
 #Handler for incoming NBNS responses
 def get_packet(pkt):


### PR DESCRIPTION
Adding default delay to 1 in order to prevent spamming if the setting is forgotten when running this tool. Updated README to reflect change as well. 